### PR TITLE
Add owner field to DDL statements with non-table objects

### DIFF
--- a/proto/OraProtoBuf.proto
+++ b/proto/OraProtoBuf.proto
@@ -119,6 +119,8 @@ message Payload {
     uint64 offset = 8;
     bool redo = 9;
     uint64 num = 10;
+    string owner = 11;
+    string table = 12;
 }
 
 message SchemaRequest {

--- a/src/builder/Builder.cpp
+++ b/src/builder/Builder.cpp
@@ -1767,13 +1767,26 @@ namespace OpenLogReplicator {
 
         if (!RedoLogRecord::nextFieldOpt(ctx, redoLogRecord1, fieldNum, fieldPos, fieldLength, 0x000011))
             return;
-
         // Field: 8
+
         if (ctx->flagsSet(Ctx::REDO_FLAGS_SHOW_DDL)) {
             // Track DDL
             uint64_t sqlLength = fieldLength;
             const char* sqlText = reinterpret_cast<char*>(redoLogRecord1->data) + fieldPos;
-            processDdl(scn, sequence, timestamp, table, redoLogRecord1->obj, redoLogRecord1->dataObj, type, seq, sqlText, sqlLength - 1);
+                        
+            if (!RedoLogRecord::nextFieldOpt(ctx, redoLogRecord1, fieldNum, fieldPos, fieldLength, 0x000012))
+                return;
+            uint64_t ownerLength = fieldLength;
+            const char* ownerText = reinterpret_cast<char*>(redoLogRecord1->data) + fieldPos;
+            // Field:9
+
+            if (!RedoLogRecord::nextFieldOpt(ctx, redoLogRecord1, fieldNum, fieldPos, fieldLength, 0x000013))
+                return;
+            uint64_t nameLength = fieldLength;
+            const char* nameText = reinterpret_cast<char*>(redoLogRecord1->data) + fieldPos;
+            // Field:10
+          
+            processDdl(scn, sequence, timestamp, table, redoLogRecord1->obj, redoLogRecord1->dataObj, type, seq, sqlText, sqlLength - 1, ownerText, ownerLength, nameText, nameLength);
         }
 
         switch (type) {

--- a/src/builder/Builder.h
+++ b/src/builder/Builder.h
@@ -1194,7 +1194,8 @@ namespace OpenLogReplicator {
         virtual void processDelete(typeScn scn, typeSeq sequence, time_t timestamp, LobCtx* lobCtx, const XmlCtx* xmlCtx, const OracleTable* table, typeObj obj,
                                    typeDataObj dataObj, typeDba bdba, typeSlot slot, typeXid xid, uint64_t offset) = 0;
         virtual void processDdl(typeScn scn, typeSeq sequence, time_t timestamp, const OracleTable* table, typeObj obj, typeDataObj dataObj, uint16_t type,
-                                uint16_t seq, const char* sql, uint64_t sqlLength) = 0;
+                                uint16_t seq, const char* sql, uint64_t sqlLength,
+				const char* owner, uint64_t ownerLength, const char* name, uint64_t nameLength) = 0;
         virtual void processBeginMessage(typeScn scn, typeSeq sequence, time_t timestamp) = 0;
         bool parseXml(const XmlCtx* xmlCtx, const uint8_t* data, uint64_t length, uint64_t offset);
 

--- a/src/builder/BuilderJson.cpp
+++ b/src/builder/BuilderJson.cpp
@@ -700,16 +700,7 @@ namespace OpenLogReplicator {
         }
 
         append(R"({"op":"ddl",)", sizeof(R"({"op":"ddl",)") - 1);
-        appendSchema(table, obj);
-
-        append(R"(,"owner":")", sizeof(R"(,"owner":")")-1);
-        appendEscape(owner, ownerLength);
-        append(R"(")", sizeof(R"(")")-1);
-
-        append(R"(,"table":)",  sizeof(R"(,"table":)")-1);
-        appendEscape(name, nameLength);
-        append(R"(")", sizeof(R"(")")-1);
-
+        appendSchema(table, obj, owner, ownerLength, name, nameLength);
         append(R"(,"sql":")", sizeof(R"(,"sql":")") - 1);
         appendEscape(sql, sqlLength);
         append(R"("})", sizeof(R"("})") - 1);

--- a/src/builder/BuilderJson.cpp
+++ b/src/builder/BuilderJson.cpp
@@ -672,7 +672,8 @@ namespace OpenLogReplicator {
     }
 
     void BuilderJson::processDdl(typeScn scn, typeSeq sequence, time_t timestamp, const OracleTable* table, typeObj obj, typeDataObj dataObj __attribute__((unused)),
-                                 uint16_t type __attribute__((unused)), uint16_t seq __attribute__((unused)), const char* sql, uint64_t sqlLength) {
+                                 uint16_t type __attribute__((unused)), uint16_t seq __attribute__((unused)), const char* sql, uint64_t sqlLength,
+                                 const char* owner, uint64_t ownerLength, const char* name, uint64_t nameLength) {
         if (newTran)
             processBeginMessage(scn, sequence, timestamp);
 
@@ -700,6 +701,15 @@ namespace OpenLogReplicator {
 
         append(R"({"op":"ddl",)", sizeof(R"({"op":"ddl",)") - 1);
         appendSchema(table, obj);
+
+        append(R"(,"owner":")", sizeof(R"(,"owner":")")-1);
+        appendEscape(owner, ownerLength);
+        append(R"(")", sizeof(R"(")")-1);
+
+        append(R"(,"table":)",  sizeof(R"(,"table":)")-1);
+        appendEscape(name, nameLength);
+        append(R"(")", sizeof(R"(")")-1);
+
         append(R"(,"sql":")", sizeof(R"(,"sql":")") - 1);
         appendEscape(sql, sqlLength);
         append(R"("})", sizeof(R"("})") - 1);

--- a/src/builder/BuilderJson.h
+++ b/src/builder/BuilderJson.h
@@ -697,7 +697,7 @@ namespace OpenLogReplicator {
         virtual void processDelete(typeScn scn, typeSeq sequence, time_t timestamp, LobCtx* lobCtx, const XmlCtx* xmlCtx, const OracleTable* table, typeObj obj,
                                    typeDataObj dataObj, typeDba bdba, typeSlot slot, typeXid xid, uint64_t offset) override;
         virtual void processDdl(typeScn scn, typeSeq sequence, time_t timestamp, const OracleTable* table, typeObj obj, typeDataObj dataObj, uint16_t type,
-                                uint16_t seq, const char* sql, uint64_t sqlLength) override;
+                                uint16_t seq, const char* sql, uint64_t sqlLength, const char* owner, uint64_t ownerLength, const char* name, uint64_t nameLength) override;
         virtual void processBeginMessage(typeScn scn, typeSeq sequence, time_t timestamp) override;
 
     public:

--- a/src/builder/BuilderJson.h
+++ b/src/builder/BuilderJson.h
@@ -297,7 +297,8 @@ namespace OpenLogReplicator {
             append("},", 2);
         }
 
-        inline void appendSchema(const OracleTable* table, typeObj obj) {
+        inline void appendSchema(const OracleTable* table, typeObj obj, const char *owner, uint64_t ownerLength,
+                                 const char *name, uint64_t nameLength) {
             if (table == nullptr) {
                 std::string ownerName;
                 std::string tableName;
@@ -307,6 +308,12 @@ namespace OpenLogReplicator {
                     appendEscape(ownerName);
                     append(R"(","table":")", sizeof(R"(","table":")") - 1);
                     appendEscape(tableName);
+                    append('"');
+                } else if (owner != nullptr && name != nullptr && ownerLength > 0 && nameLength > 0) {
+                    append(R"("schema":{"owner":")", sizeof(R"("schema":{"owner":")") - 1);
+                    appendEscape(owner, ownerLength);
+                    append(R"(","table":")", sizeof(R"(","table":")") - 1);
+                    appendEscape(name, nameLength);
                     append('"');
                 } else {
                     append(R"("schema":{"table":")", sizeof(R"("schema":{"table":")") - 1);
@@ -457,6 +464,10 @@ namespace OpenLogReplicator {
             }
 
             append('}');
+        }
+
+        inline void appendSchema(const OracleTable* table, typeObj obj) {
+            appendSchema(table, obj, nullptr, 0, nullptr, 0);
         }
 
         inline void appendHex2(uint8_t value) {

--- a/src/builder/BuilderProtobuf.cpp
+++ b/src/builder/BuilderProtobuf.cpp
@@ -245,7 +245,7 @@ namespace OpenLogReplicator {
 
     void BuilderProtobuf::processDdl(typeScn scn, typeSeq sequence, time_t timestamp, const OracleTable* table __attribute__((unused)), typeObj obj,
                                      typeDataObj dataObj __attribute__((unused)), uint16_t type __attribute__((unused)), uint16_t seq __attribute__((unused)),
-                                     const char* sql, uint64_t sqlLength) {
+                                     const char* sql, uint64_t sqlLength, const char* owner, uint64_t ownerLength, const char* name, uint64_t nameLength) {
         if (newTran)
             processBeginMessage(scn, sequence, timestamp);
 
@@ -262,6 +262,8 @@ namespace OpenLogReplicator {
             payloadPB->set_op(pb::DDL);
             appendSchema(table, obj);
             payloadPB->set_ddl(sql, sqlLength);
+            payloadPB->set_owner(owner, ownerLength);
+            payloadPB->set_table(name, nameLength);
         }
 
         if ((messageFormat & MESSAGE_FORMAT_FULL) == 0) {

--- a/src/builder/BuilderProtobuf.h
+++ b/src/builder/BuilderProtobuf.h
@@ -429,7 +429,7 @@ namespace OpenLogReplicator {
         virtual void processDelete(typeScn scn, typeSeq sequence, time_t timestamp, LobCtx* lobCtx, const XmlCtx* xmlCtx, const OracleTable* table, typeObj obj,
                                    typeDataObj dataObj, typeDba bdba, typeSlot slot, typeXid xid, uint64_t offset) override;
         virtual void processDdl(typeScn scn, typeSeq sequence, time_t timestamp, const OracleTable* table, typeObj obj, typeDataObj dataObj, uint16_t type,
-                                uint16_t seq, const char* sql, uint64_t sqlLength) override;
+                                uint16_t seq, const char* sql, uint64_t sqlLength, const char* owner, uint64_t ownerLength, const char* name, uint64_t nameLength) override;
         void processBeginMessage(typeScn scn, typeSeq sequence, time_t timestamp) override;
 
     public:


### PR DESCRIPTION
Tested with objects below:

1. Views
2. Indexes
3. Stored functions
4. Stored procedures
5. Packages
6. Synonyms
7. Database triggers
8. Sequences
9. Java classes
10. Java sources