### PR TITLE
Update types.h

### DIFF
--- a/src/common/types.h
+++ b/src/common/types.h
@@ -21,6 +21,7 @@ along with OpenLogReplicator; see the file LICENSE;  If not see
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <cstdint>
 
 #include "../../config.h"
 


### PR DESCRIPTION
Fixed a bug that occurs in the distribution _**Linux 5.15.153.1-microsoft-standard-WSL2 (Ubuntu)**_  due to a missing header <cstdint.h> for `uint32_t` and other types. This interfered with the build using gcc-13 tools.
A brief excerpt:
```
/home/igor/OpenLogReplicator/src/common/types.h:26:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   25 | #include "../../config.h"
  +++ |+#include <cstdint>
   26 | 
```