### PR TITLE
fix: correct subnormal float/double decode exponent

### DIFF
--- a/src/builder/Builder.cpp
+++ b/src/builder/Builder.cpp
@@ -630,6 +630,8 @@ namespace OpenLogReplicator {
 
             if (exponent > 0)
                 significand += 0x800000;
+            else
+                exponent = 1;
             exponent -= 0x7F;
             return ldexp((static_cast<double>(significand)) / (static_cast<double>(0x800000)), exponent);
         }
@@ -640,6 +642,8 @@ namespace OpenLogReplicator {
         significand = 0x7FFFFF - significand;
         if (exponent < 0xFF)
             significand += 0x800000;
+        else
+            exponent = 0xFE;
         exponent = 0x80 - exponent;
         return -ldexp(((static_cast<double>(significand) / static_cast<double>(0x800000))), exponent);
     }
@@ -662,6 +666,8 @@ namespace OpenLogReplicator {
 
             if (exponent > 0)
                 significand += 0x10000000000000;
+            else
+                exponent = 1;
             exponent -= 0x3FF;
             return ldexpl(static_cast<long double>(significand) / static_cast<long double>(0x10000000000000), exponent);
         }
@@ -672,6 +678,8 @@ namespace OpenLogReplicator {
         significand = 0xFFFFFFFFFFFFF - significand;
         if (exponent < 0x7FF)
             significand += 0x10000000000000;
+        else
+            exponent = 0x7FE;
         exponent = 0x400 - exponent;
         return -ldexpl(static_cast<long double>(significand) / static_cast<long double>(0x10000000000000), exponent);
     }


### PR DESCRIPTION
## Summary

IEEE 754 subnormal (denormalized) values are decoded with the wrong exponent,
producing approximately half the correct value.

For subnormals (exponent field == 0), the effective exponent should be `1 - bias`,
not `0 - bias`. The current code falls through without adjusting the exponent,
resulting in values shifted by a factor of 2.

## Example

BINARY_FLOAT `1.401298e-45` (smallest positive subnormal) decodes as `7.006492e-46`.

## Fix

Set `exponent = 1` before subtracting the bias in the subnormal path, for both
positive and negative cases of `decodeFloat()` and `decodeDouble()`.

## Test

Standalone test to reproduce and verify:

```cpp
// Build: g++ -std=c++17 -o test_subnormal test_subnormal.cpp

#include <cmath>
#include <cstdint>
#include <cstdio>
#include <limits>

static double decodeFloat(const uint8_t* data) {
    // ... copy from Builder.cpp ...
}

int main() {
    // Smallest positive subnormal float
    // IEEE 754: sign=0, exp=0x00, sig=0x000001
    // Oracle:   sign flipped -> {0x80, 0x00, 0x00, 0x01}
    const uint8_t data[] = {0x80, 0x00, 0x00, 0x01};
    double result = decodeFloat(data);
    printf("got: %.6e, expected: %.6e\n", result, 1.401298e-45);
    // Without fix: 7.006492e-46 (wrong)
    // With fix:    1.401298e-45 (correct)
}
```