### PR TITLE
feat: add ROWID column type (type# 69) decoding

### DIFF
--- a/src/builder/Builder.cpp
+++ b/src/builder/Builder.cpp
@@ -598,6 +598,32 @@ namespace OpenLogReplicator {
                 }
                 break;
 
+            case SysCol::COLTYPE::ROWID:
+                // ROWID (type 69) in redo: 10 bytes big-endian
+                //   dataObj(4) + DBA(4, afn<<22|block) + slot(2)
+                // Output as Oracle base64 ROWID string (e.g. AAASnuAAMAAAAKtAAA)
+                if (size == 10) {
+                    const typeDataObj rDataObj = (static_cast<typeDataObj>(data[0]) << 24) |
+                            (static_cast<typeDataObj>(data[1]) << 16) |
+                            (static_cast<typeDataObj>(data[2]) << 8) |
+                            static_cast<typeDataObj>(data[3]);
+                    const typeDba rDba = (static_cast<typeDba>(data[4]) << 24) |
+                            (static_cast<typeDba>(data[5]) << 16) |
+                            (static_cast<typeDba>(data[6]) << 8) |
+                            static_cast<typeDba>(data[7]);
+                    const typeSlot rSlot = (static_cast<typeSlot>(data[8]) << 8) |
+                            static_cast<typeSlot>(data[9]);
+                    RowId rowId(rDataObj, rDba, rSlot);
+                    // Output as base64 string (Oracle's standard ROWID display format)
+                    // Not using columnRowId — that uses toHex for UROWID compatibility
+                    rowId.toString(reinterpret_cast<char*>(valueBuffer));
+                    valueSize = RowId::SIZE;
+                    columnString(column->name);
+                } else {
+                    columnUnknown(column->name, data, size);
+                }
+                break;
+
             case SysCol::COLTYPE::UROWID:
                 if (size == 13 && data[0] == 0x01) {
                     RowId rowId;

--- a/src/builder/BuilderJson.h
+++ b/src/builder/BuilderJson.h
@@ -69,6 +69,7 @@ namespace OpenLogReplicator {
                     && typeNo != SysCol::COLTYPE::TIMESTAMP
                     && typeNo != SysCol::COLTYPE::INTERVAL_YEAR_TO_MONTH
                     && typeNo != SysCol::COLTYPE::INTERVAL_DAY_TO_SECOND
+                    && typeNo != SysCol::COLTYPE::ROWID
                     && typeNo != SysCol::COLTYPE::UROWID
                     && typeNo != SysCol::COLTYPE::TIMESTAMP_WITH_LOCAL_TZ)
                     return;
@@ -498,6 +499,11 @@ namespace OpenLogReplicator {
 
                         case SysCol::COLTYPE::INTERVAL_DAY_TO_SECOND:
                             append(std::string_view(R"("interval day to second","length":)"));
+                            appendDec(table->columns[column]->length);
+                            break;
+
+                        case SysCol::COLTYPE::ROWID:
+                            append(std::string_view(R"("rowid","length":)"));
                             appendDec(table->columns[column]->length);
                             break;
 

--- a/src/builder/BuilderProtobuf.h
+++ b/src/builder/BuilderProtobuf.h
@@ -64,6 +64,7 @@ namespace OpenLogReplicator {
                     && typeNo != SysCol::COLTYPE::TIMESTAMP
                     && typeNo != SysCol::COLTYPE::INTERVAL_YEAR_TO_MONTH
                     && typeNo != SysCol::COLTYPE::INTERVAL_DAY_TO_SECOND
+                    && typeNo != SysCol::COLTYPE::ROWID
                     && typeNo != SysCol::COLTYPE::UROWID
                     && typeNo != SysCol::COLTYPE::TIMESTAMP_WITH_LOCAL_TZ)
                     return;
@@ -299,6 +300,11 @@ namespace OpenLogReplicator {
 
                         case SysCol::COLTYPE::INTERVAL_DAY_TO_SECOND:
                             columnPB->set_type(pb::INTERVAL_DAY_TO_SECOND);
+                            columnPB->set_length(static_cast<int32_t>(table->columns[column]->length));
+                            break;
+
+                        case SysCol::COLTYPE::ROWID:
+                            columnPB->set_type(pb::UROWID);
                             columnPB->set_length(static_cast<int32_t>(table->columns[column]->length));
                             break;
 

--- a/src/common/table/SysCol.h
+++ b/src/common/table/SysCol.h
@@ -75,6 +75,7 @@ namespace OpenLogReplicator {
             RAW                     = 23,
             LONG_RAW                = 24,
             XMLTYPE                 = 58,
+            ROWID                   = 69,
             CHAR                    = 96,
             FLOAT                   = 100,
             DOUBLE                  = 101,


### PR DESCRIPTION
## Summary

ROWID columns (Oracle type# 69) are currently unsupported — their values are
silently dropped from the output. This adds decoding support.

## Details

ROWID in redo logs is stored as 10 bytes big-endian:
- `dataObj` (4 bytes) + `DBA` (4 bytes, afn<<22|block) + `slot` (2 bytes)

Output uses Oracle's standard base64 ROWID format (e.g. `AAASnuAAMAAAAKtAAA`),
matching what `SELECT ROWID FROM ...` returns.

UROWID (type 208) is unchanged — it keeps the existing hex format since UROWID
can store variable-length logical ROWIDs from index-organized tables where base64
encoding would be incorrect.

## Changes

- `SysCol.h`: add `ROWID = 69` to COLTYPE enum
- `Builder.cpp`: decode 10-byte ROWID and output as base64 string
- `BuilderJson.h`: add ROWID to known types filter + schema metadata
- `BuilderProtobuf.h`: add ROWID to known types filter + schema metadata

## Verification

Tested against Oracle Free 23ai — ROWID values match LogMiner's `SQL_REDO` output.
Format verified by hex-dumping raw redo log bytes and matching against LogMiner's
base64 ROWID.