### PR TITLE
feat(build): add conditional compilation for SO_REUSEPORT

### DIFF
--- a/src/stream/StreamNetwork.cpp
+++ b/src/stream/StreamNetwork.cpp
@@ -107,8 +107,13 @@ namespace OpenLogReplicator {
             throw RuntimeException(10061, "network error, errno: " + std::to_string(errno) + ", message: " + strerror(errno) + " (6)");
 
         constexpr int64_t opt = 1;
-        if (setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt)) != 0)
+        if (setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) != 0)
             throw RuntimeException(10061, "network error, errno: " + std::to_string(errno) + ", message: " + strerror(errno) + " (7)");
+
+#ifdef SO_REUSEPORT
+        if (setsockopt(serverFD, SOL_SOCKET, SO_REUSEPORT, &opt, sizeof(opt)) != 0)
+            throw RuntimeException(10061, "network error, errno: " + std::to_string(errno) + ", message: " + strerror(errno) + " (21)");
+#endif
 
         if (bind(serverFD, res->ai_addr, res->ai_addrlen) < 0)
             throw RuntimeException(10061, "network error, errno: " + std::to_string(errno) + ", message: " + strerror(errno) + " (8)");


### PR DESCRIPTION
## Summary

Add conditional compilation for the `SO_REUSEPORT` socket option, which is not supported on all platforms (e.g., macos).

## Changes

- Wrap `SO_REUSEPORT` usage with `#ifdef` checks in `StreamNetwork.cpp`
- Allows compilation on systems without this socket option

## Motivation

This change enables OpenLogReplicator to build and run on macos and other systems that do not implement `SO_REUSEPORT`.

## Testing

- [x] Compiled on Linux with `SO_REUSEPORT` support
- [x] Compiled on Mac without `SO_REUSEPORT` support