### PR TITLE
fix: client reconnect: messages held before the current buffer aren't replayed

### DIFF
--- a/src/builder/Builder.h
+++ b/src/builder/Builder.h
@@ -107,10 +107,10 @@ namespace OpenLogReplicator {
     class Builder {
     public:
         static constexpr uint64_t OUTPUT_BUFFER_DATA_SIZE = Ctx::MEMORY_CHUNK_SIZE - sizeof(BuilderQueue);
-
-    protected:
+        // Read by the writer when it rewinds the stream for a reconnecting client
         static constexpr uint64_t BUFFER_START_UNDEFINED{0xFFFFFFFFFFFFFFFF};
 
+    protected:
         static constexpr uint64_t VALUE_BUFFER_MIN{1048576};
         static constexpr uint64_t VALUE_BUFFER_MAX{4294967296};
 

--- a/src/writer/Writer.cpp
+++ b/src/writer/Writer.cpp
@@ -55,6 +55,11 @@ namespace OpenLogReplicator {
     void Writer::createMessage(BuilderMsg* msg) {
         ++sentMessages;
 
+        // A message can be walked over more than once when a reconnecting client rewinds the
+        // stream, so a confirmation left over from an earlier pass has to be cleared before the
+        // message is queued again, otherwise confirmMessage() drops it before the client acks it.
+        msg->unsetFlag(BuilderMsg::OUTPUT_BUFFER::CONFIRMED);
+
         queue[currentQueueSize++] = msg;
         hwmQueueSize = std::max(currentQueueSize, hwmQueueSize);
     }
@@ -100,7 +105,19 @@ namespace OpenLogReplicator {
         }
         currentQueueSize = 0;
 
-        oldSize = builderQueue->start;
+        // Rewind to the oldest buffer still held rather than to the head of whichever buffer the
+        // writer happens to sit in. A buffer is only released once the client has confirmed it, so
+        // this is the earliest position a client may legitimately continue from, and isNewData()
+        // then filters forward to the requested c_scn/c_idx. Restarting from the current buffer
+        // instead silently drops every unconfirmed message held in the buffers before it.
+        builderQueue = builder->firstBuilderQueue;
+        const uint64_t bufferStart = builderQueue->start;
+        oldSize = bufferStart;
+
+        // A buffer has no message boundary until its first message ends in it, so there is nothing
+        // to replay from it yet and the read resumes at its head.
+        if (unlikely(oldSize == Builder::BUFFER_START_UNDEFINED))
+            oldSize = 0;
     }
 
     void Writer::confirmMessage(BuilderMsg* msg) {


### PR DESCRIPTION
## Problem

When a client reconnects and sends `CONTINUE` with a position earlier than the last message it received, any unconfirmed messages sitting in buffers older than the one the writer currently occupies are never re-sent. The client is only given messages that follow the requested position, so those messages are silently skipped with no errors or warnings. For a consumer that resumes from its last committed position rather than its last received position, this results in data loss on restart.

## Cause

`WriterStream::processContinue` calls `resetMessageQueue()` to rewind the stream. That rewind used the head of whichever buffer the writer happened to be in:
```
oldSize = builderQueue->start;
```
`builderQueue` points at the writer's current position, not at the oldest data still retained. Every buffer before it is still held; buffers are only released once the client confirms them, but the read restarts past them, so their contents are never walked again.

A second related defect is that `confirmMessage` sets `OUTPUT_BUFFER::CONFIRMED` on a message, and the main loop pops confirmed messages off the queue head. A message walked over a second time during a replay still carries `CONFIRMED` from the earlier pass, so it is discarded before the reconnecting client has acknowledged it.

## Proposed solution

Rewind to the oldest buffer still held. 
```
builderQueue = builder->firstBuilderQueue;
oldSize = builderQueue->start;
if (unlikely(oldSize == Builder::BUFFER_START_UNDEFINED))
    oldSize = 0;
```
A buffer that has not yet had a message end in it has no message boundary to replay from, so the read resumes at its head. `BUFFER_START_UNDEFINED` moves from protected to public so that the writer can test for it.

This is seen as safe because a buffer is only released once it's confirmed, so `firstBuilderQueue` is the earliest position any client can legitimately ask to continue from. `Metadata::isNewData()` then filters forward to the requested `c_scn` / `c_idx` so the extra messages walked are discarded rather than resent; the change therefore only costs a longer walk, never duplicates.

For Debezium, it would be useful if this could be backported to 1.9 and earlier, based on supported versions. This is because Debezium isn't currently compatible with 2.0, which has changed how some parts of the data work.